### PR TITLE
Update Dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,6 +3,6 @@ FROM jenkins/jenkins:latest
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc.yaml
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+RUN jenkins-plugin-cli --verbose --plugin-file /usr/share/jenkins/ref/plugins.txt
 COPY casc.yaml /usr/share/jenkins/ref/casc.yaml
 COPY secrets/jenkins_keystore.jks /usr/share/jenkins/ref/jenkins_keystore.jks


### PR DESCRIPTION
Replaced step for plugin install with the use of jenkins-plugin-cli, rather using /usr/local/bin/install-plugins.sh.
Reason: The direct call to installer script will fail behind corporate proxy, while jenkins-plugin-cli does work.
See also: https://github.com/jenkinsci/docker and https://github.com/jenkinsci/plugin-installation-manager-tool